### PR TITLE
Update install_arm-none-eabi-gcc.sh

### DIFF
--- a/tools/install_arm-none-eabi-gcc.sh
+++ b/tools/install_arm-none-eabi-gcc.sh
@@ -90,7 +90,7 @@ cd ${GCC_VERSION}
 ln -s ../${NEWLIB_VERSION}/newlib .
 mkdir arm-none-eabi
 cd arm-none-eabi
-../configure --target=arm-none-eabi --prefix=/opt/arm-none-eabi --enable-languages=c --with-newlib
+../configure --target=arm-none-eabi --prefix=/opt/arm-none-eabi --enable-languages=c --with-newlib --enable-newlib-io-long-long
 make
 sudo make install
 cd ../../


### PR DESCRIPTION
Build the toolchain with --enable-newlib-io-long-long to avoid build failing with:

   main.c:64:2: error: #error "newlib lacks support of long long type in IO functions. Please use a toolchain that was compiled with option --enable-newlib-io-long-long."